### PR TITLE
Add example HeroBanner class

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,19 @@ if(function_exists('__autoload')) {
   spl_autoload_register('__autoload');
 }
 ```
+
+## Using a CMB2Field Class
+
+To access the base CMB2Fields class in a view, assign a variable to new-up the class `$cmb2_fields = new CMB2Fields(get_the_ID());`
+
+Typically you will always want to pass the current page/post/custom post type (singular) ID to the CMB2Fields (or any extended) class as this will be the ID to which custom meta data is fetched from the WordPress database.
+
+To use a custom class, such as the example `HeroBanner` class, you would simply replace it's class name in place of the base class:
+
+```$hero_banner_fields = new HeroBanner(get_the_ID());```
+
+You can then call any of the methods assoicated with the `HeroBanner` class, whether that be a method specific to itself or of the parent `CMB2Fields` class:
+
+```echo $hero_banner_fields->field('hero-image');```
+
+`hero-image` refers to a custom meta field named `hero-image` in this example.

--- a/examples/class.HeroBanner.php
+++ b/examples/class.HeroBanner.php
@@ -1,0 +1,32 @@
+<?php
+
+Class HeroBanner extends CMB2Fields {
+  public $field_prefix = 'hero_banner_';
+
+  public function __construct($post_id, $ignore_parent = false) {
+    $parent_post_id = $this->parent_post_id($post_id);
+    $hero_banner_id = $ignore_parent === true ?
+                      $post_id :
+                      $parent_post_id;
+
+    parent::__construct($hero_banner_id);
+  }
+
+  public function render_video($field) {
+    if(!empty($this->field($field))) {
+      include(locate_template('templates/hero/vimeo-video-tpl.php'));
+    }
+  }
+
+  public function vimeo_url($field) {
+    $vimeo_url = $this->field($field);
+
+    return !empty($vimeo_url) ? $this->vimeo_url_formatter($vimeo_url) : '';
+  }
+
+  private function vimeo_url_formatter($vimeo_url) {
+    $vimeo_id = (int) substr(parse_url($vimeo_url, PHP_URL_PATH), 1);
+
+    return 'https://player.vimeo.com/video/' . $vimeo_id;
+  }
+}


### PR DESCRIPTION
- Adds example HeroBanner class which extends from the base CMB2Fields
  class.
- Updates the README with information on how to use the standard base
  class and also how to use an extended class as per this example class
